### PR TITLE
Destroy editors for properties removed in Edit JSON modal

### DIFF
--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -190,6 +190,7 @@ export class MultipleEditor extends AbstractEditor {
       })
       const unrecognizedPropertyWarning = document.createElement('span')
       unrecognizedPropertyWarning.textContent = 'Property "' + this.key + '" has been removed from the schema. Please remove before saving changes.'
+      unrecognizedPropertyWarning.classList.add('unrecognized-warning-text')
       unrecognizedPropertyEl.appendChild(unrecognizedPropertyWarning)
       unrecognizedPropertyEl.appendChild(removeBtn)
       container.appendChild(unrecognizedPropertyEl)

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -170,11 +170,35 @@ export class MultipleEditor extends AbstractEditor {
   build () {
     const { container } = this
 
+    if (this.isUnrecognizedProperty()) {
+      container.classList.add('unrecognized-property')
+    }
+
     this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
     this.container.appendChild(this.header)
 
     this.switcher = this.theme.getSwitcher(this.display_text)
     container.appendChild(this.switcher)
+
+    if (this.isUnrecognizedProperty()) {
+      const unrecognizedPropertyEl = document.createElement('div')
+      unrecognizedPropertyEl.classList.add('unrecognized-property')
+      var removeBtn = this.getButton('Delete', 'delete', 'Delete property')
+      removeBtn.addEventListener('click', e => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        if (this.parent && this.parent.removeObjectProperty) {
+          this.parent.removeObjectProperty(this.key)
+        }
+      })
+      const unrecognizedPropertyWarning = document.createElement('span')
+      unrecognizedPropertyWarning.textContent = 'Property "' + this.key + '" has been removed from the schema. Please remove before saving changes.'
+      unrecognizedPropertyEl.appendChild(unrecognizedPropertyWarning)
+      unrecognizedPropertyEl.appendChild(removeBtn)
+      container.appendChild(unrecognizedPropertyEl)
+    }
+
     this.switcher.addEventListener('change', e => {
       e.preventDefault()
       e.stopPropagation()
@@ -213,6 +237,10 @@ export class MultipleEditor extends AbstractEditor {
     })
 
     this.switchEditor(0)
+  }
+
+  isUnrecognizedProperty () {
+    return this.schema.type !== 'any' && !this.schema.oneOf && !this.schema.anyOf
   }
 
   onChildEditorChange (editor) {

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -170,10 +170,6 @@ export class MultipleEditor extends AbstractEditor {
   build () {
     const { container } = this
 
-    if (this.isUnrecognizedProperty()) {
-      container.classList.add('unrecognized-property')
-    }
-
     this.header = this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired())
     this.container.appendChild(this.header)
 

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -849,7 +849,7 @@ export class ObjectEditor extends AbstractEditor {
 
     try {
       const json = JSON.parse(this.editjson_textarea.value)
-      this.setValue(json)
+      this.setValue(json, undefined, true)
       this.hideEditJSON()
       this.onChange(true)
     } catch (e) {
@@ -1156,7 +1156,7 @@ export class ObjectEditor extends AbstractEditor {
     return false
   }
 
-  setValue (value, initial) {
+  setValue (value, initial, fromEditJson) {
     value = value || {}
 
     if (typeof value !== 'object' || Array.isArray(value)) value = {}
@@ -1168,7 +1168,12 @@ export class ObjectEditor extends AbstractEditor {
         this.addObjectProperty(i)
         editor.setValue(value[i], initial)
       } else {
-        editor.setValue(editor.getDefault(), initial)
+        if (fromEditJson) {
+          this.removeObjectProperty(i)
+          editor.destroy()
+        } else {
+          editor.setValue(editor.getDefault(), initial)
+        }
       }
     })
 

--- a/src/iconlibs/foundation3.js
+++ b/src/iconlibs/foundation3.js
@@ -22,7 +22,7 @@ const mapping = {
 }
 
 export class foundation3Iconlib extends AbstractIconLib {
-  constructor () {
+  constructor() {
     super(iconPrefix, mapping)
   }
 }


### PR DESCRIPTION
Adds features needed to fix https://github.com/desmosinc/classroom/issues/12018.

* Fixes a bug where properties would not be removed from the editor if they were manually removed in the "Edit JSON" textarea.
* Adds a warning to properties that are not included in the schema with a button to remove the property. These extra properties will not cause validation errors, but they will be displayed prominently to activity authors.

These changes can be seen in action in Classroom here: https://github.com/desmosinc/classroom/pull/12078

I hope to be able to contribute the first fix upstream, but the latter is pretty specific to our workflow.

