### PR TITLE
Fix "Multiple" editor warnings

### DIFF
--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -237,7 +237,7 @@ export class MultipleEditor extends AbstractEditor {
   }
 
   isUnrecognizedProperty () {
-    return this.schema.type !== 'any' && !this.schema.oneOf && !this.schema.anyOf
+    return this.schema.type !== 'any' && !this.oneOf && !this.anyOf
   }
 
   onChildEditorChange (editor) {


### PR DESCRIPTION
The multiple editor deletes the schema oneOf and anyOf properties. Check local variables for these instead
